### PR TITLE
git: improve sparse file support

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -330,6 +330,8 @@ func LsFilesLFS() (*subprocess.BufferedCmd, error) {
 		"ls-files",
 		"--cached",
 		"--full-name",
+		"--sparse",
+		"--exclude-standard",
 		"-z",
 		"--format=%(objectmode) %(objecttype) %(objectname) %(objectsize)\t%(path)",
 		":(top,attr:filter=lfs)",


### PR DESCRIPTION
When we invoke `git ls-files` to try to find all LFS files, we don't honour sparse file paths or exclusions.  While we should never actually traverse excluded files, using the `--exclude-standard` option can avoid loading some data with filtered clones, which may result in less data being downloaded.

In addition, we can honour sparse checkouts, since this code path is only used to handle the working tree and we know that the only files we need to consider are those Git actually put in the working tree.  The `--sparse` option is new in 2.35, but we already require 2.42 above, so we can use it unconditionally.